### PR TITLE
Add php7 as a requirement in composer file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "eclipsegc/plugins",
+  "description": "This library provides a set of tools designed to ease discovery of 'like' objects, assembly of those objects into a common dictionary, and facilitate common factory patterns for objects within the dictionary.",
   "authors": [
     {
       "name": "Kris Vanderwater",
@@ -12,6 +13,9 @@
     "psr-4": {
       "EclipseGc\\Plugin\\": "src/"
     }
+  },
+  "require": {
+    "php": ">=7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.4",


### PR DESCRIPTION
1. Add php7 as a requirement for the repo.
2. Added the **description** to the composer.json so that the composer file being validated.

During composer validate
`
$ composer validate
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
`

@TODO there's also a need to specify about the license.Its up to the author as there's only a single collaborator to the project.
